### PR TITLE
Handle relative urls correctly with a reverse proxy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -92,3 +92,4 @@ sacredboard/Scripts/
 
 \.idea/
 node_modules
+*~

--- a/sacredboard/app/webapi/proxy.py
+++ b/sacredboard/app/webapi/proxy.py
@@ -1,0 +1,31 @@
+# prody implementation
+
+# http://blog.macuyiko.com/post/2016/fixing-flask-url_for-when-behind-mod_proxy.html
+
+
+class ReverseProxied(object):
+    """
+    Allow to use a reverse proxy
+    http://blog.macuyiko.com/post/2016/fixing-flask-url_for-when-behind-mod_proxy.html
+    """
+
+    def __init__(self, app, script_name=None, scheme=None, server=None):
+        self.app = app
+        self.script_name = script_name
+        self.scheme = scheme
+        self.server = server
+
+    def __call__(self, environ, start_response):
+        script_name = environ.get('HTTP_X_SCRIPT_NAME', '') or self.script_name
+        if script_name:
+            environ['SCRIPT_NAME'] = script_name
+            path_info = environ['PATH_INFO']
+            if path_info.startswith(script_name):
+                environ['PATH_INFO'] = path_info[len(script_name):]
+        scheme = environ.get('HTTP_X_SCHEME', '') or self.scheme
+        if scheme:
+            environ['wsgi.url_scheme'] = scheme
+        server = environ.get('HTTP_X_FORWARDED_SERVER', '') or self.server
+        if server:
+            environ['HTTP_HOST'] = server
+        return self.app(environ, start_response)

--- a/sacredboard/bootstrap.py
+++ b/sacredboard/bootstrap.py
@@ -15,7 +15,7 @@ from sacredboard.app.config import jinja_filters
 from sacredboard.app.data.filestorage import FileStorage
 from sacredboard.app.data.mongodb import PyMongoDataAccess
 from sacredboard.app.webapi import routes, metrics
-from sacredboard.app.prody import ReverseProxied
+from sacredboard.app.webapi.proxy import ReverseProxied
 
 locale.setlocale(locale.LC_ALL, '')
 app = Flask(__name__)
@@ -42,9 +42,10 @@ app = Flask(__name__)
                    "File Storage observer. (experimental)")
 @click.option("--no-browser", is_flag=True, default=False,
               help="Do not open web browser automatically.")
-@click.option("-proxy_sub_url", default="/",
-              help="Run in sub-url mode. Example '-proxy_sub_url /sacredboard/'"
-              "Use with proxy")
+@click.option("-sub_url", default="/",
+              help="Run the app on a sub-url. Example '-sub_url /sacredboard/' "
+              "maps localhost:5000/ -> localhost:5000/sacredboard/"
+              "Use with Apache proxy")
 @click.option("--debug", is_flag=True, default=False,
               help="Run the application in Flask debug mode "
                    "(for development).")

--- a/sacredboard/bootstrap.py
+++ b/sacredboard/bootstrap.py
@@ -44,8 +44,8 @@ app = Flask(__name__)
               help="Do not open web browser automatically.")
 @click.option("-sub_url", default="/",
               help="Run the app on a sub-url. Example '-sub_url /sacredboard/' "
-              "maps localhost:5000/ -> localhost:5000/sacredboard/"
-              "Use with Apache proxy")
+              "maps localhost:5000/ -> localhost:5000/sacredboard/. "
+              "Useful with http proxy.")
 @click.option("--debug", is_flag=True, default=False,
               help="Run the application in Flask debug mode "
                    "(for development).")

--- a/sacredboard/static/scripts/runs/metricsViewer/ProxiedMetric.js
+++ b/sacredboard/static/scripts/runs/metricsViewer/ProxiedMetric.js
@@ -62,7 +62,7 @@ define(["runs/Metric", "knockout", "jquery"], function (Metric, ko, $) {
             }
             var self = this;
             this._fetchingInProgress = true;
-            $.getJSON("/api/run/" + this._runId + "/metric/" + this._metricId,
+            $.getJSON("api/run/" + this._runId + "/metric/" + this._metricId,
                 function (data) {
                     self._values(data["values"]);
                     self._steps(data["steps"]);

--- a/sacredboard/static/scripts/runs/runTable.js
+++ b/sacredboard/static/scripts/runs/runTable.js
@@ -71,7 +71,7 @@ define(["bootstrap", "datatable", "datatables-bootstrap", "runs/detailView", "jq
                  * and additional URL parameters to be passed to the backend.
                  */
                 ajax: {
-                    url: "/api/run",
+                    url: "api/run",
                     data: function (request) {
                         request.queryFilter = JSON.stringify(createRunTable.queryFilter);
 
@@ -132,7 +132,7 @@ define(["bootstrap", "datatable", "datatables-bootstrap", "runs/detailView", "jq
                     var id = row.data().id;
                     var loadDetailData = function () {
                         $.ajax({
-                            url: "/api/run/" + id
+                            url: "api/run/" + id
                         }).done(function (data) {
                             if (data.data[0].id != row.data().id) {
                                 /* Before this ajax function was called,


### PR DESCRIPTION
Allows sacredboard to run behind a reverse proxy, 

- added the `sub_url` CLI flag (following this [blog post](http://blog.macuyiko.com/post/2016/fixing-flask-url_for-when-behind-mod_proxy.html)).
- jquery ajax calls now use relative url's (replaced "/app/run" -> "app/run") in .js files