### PR TITLE
Fix #90: runs not displayed using FileStorage when info.json missing.

### DIFF
--- a/sacredboard/app/data/filestorage/rundao.py
+++ b/sacredboard/app/data/filestorage/rundao.py
@@ -58,7 +58,11 @@ class FileStoreRunDAO(RunDAO):
         """
         config = _read_json(_path_to_config(self.directory, run_id))
         run = _read_json(_path_to_run(self.directory, run_id))
-        info = _read_json(_path_to_info(self.directory, run_id))
+        try:
+            info = _read_json(_path_to_info(self.directory, run_id))
+        except IOError:
+            info = {}
+
         return _create_run(run_id, run, config, info)
 
 


### PR DESCRIPTION
Hi, this is a simple proposal to fix issue #90, where no runs are displayed when using the FileStorage backend and info.json files are missing.