### PR TITLE
Add logarithmic x-axis type

### DIFF
--- a/sacredboard/static/scripts/metricsPlot/template.html
+++ b/sacredboard/static/scripts/metricsPlot/template.html
@@ -20,7 +20,11 @@
             <label>x-axis type</label>
             <div class="radio">
                 <label><input type="radio" name="x-axis-type" value="linear"
-                              data-bind="checked: xType">steps</label>
+                              data-bind="checked: xType">linear steps</label>
+            </div>
+            <div class="radio">
+                <label><input type="radio" name="x-axis-type" value="log"
+                              data-bind="checked: xType">logarithmic steps</label>
             </div>
             <div class="radio">
                 <label><input type="radio" name="x-axis-type" value="date"


### PR DESCRIPTION
Resolves #106. Was as easy as adding just another button since the type is readily recognized by the plot. This is because the `log` type is implemented for the y-axis already.